### PR TITLE
Add quotes around exec argument

### DIFF
--- a/wocker
+++ b/wocker
@@ -367,11 +367,11 @@ case "$1" in
         cid=$(docker ps -q)
         if [[ ! $cid =~ $'\n' ]]; then
           if [[ "$2" = 'shell' ]]; then
-            docker exec -u $USER -it $cid wp ${@:2}
+            docker exec -u $USER -it $cid wp "${@:2}"
           elif [[ "$2" = 'cli' ]] && [[ "$3" = 'update' ]]; then
             docker exec -it $cid wp cli update --nightly --allow-root
           else
-            docker exec -u $USER $cid wp ${@:2}
+            docker exec -u $USER $cid wp "${@:2}"
           fi
         fi
       fi


### PR DESCRIPTION
This prevents 'Too many positional arguments' errors when the spaces are
inside the arguments.

See: https://github.com/wp-cli/wp-cli/issues/1928#issuecomment-122901905

p.s.: thank you for this awesome tool! :100: :+1: 