### PR TITLE
Add option enable ssh auth for wordmove

### DIFF
--- a/wocker
+++ b/wocker
@@ -193,7 +193,7 @@ case "$1" in
 
       # Use existing WordPress files to run a container
       elif [[ $cname && -d ~/data/${cname} ]]; then
-        docker run -d --name $cname -p 80:80 -p 3306:3306 -p 8025:8025 -v ~/data/${cname}:${DOCROOT}:rw $image
+        docker run -d --name $cname -p 80:80 -p 3306:3306 -p 8025:8025 -v ~/data/${cname}:${DOCROOT}:rw -v ${SSH_AUTH_SOCK}:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent $image
 
       # Or copy WordPress files from the image to run a container
       else
@@ -211,7 +211,7 @@ case "$1" in
         cname=$dirname && \
         docker cp $(docker ps -l -q):${DOCROOT} ~/data/${dirname} && \
         docker rm -f $(docker ps -l -q) && \
-        docker run -d --name $cname -p 80:80 -p 3306:3306 -p 8025:8025 -v ~/data/${dirname}:${DOCROOT}:rw $image
+        docker run -d --name $cname -p 80:80 -p 3306:3306 -p 8025:8025 -v ~/data/${dirname}:${DOCROOT}:rw -v ${SSH_AUTH_SOCK}:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent $image
       fi
 
     fi


### PR DESCRIPTION
Wordmove enable connecting remote server by Local SSH key, none password.
When create container, enable ssh fowarding.

Forwarding Local SSH key -> BargeOS -> Container, when Local key to BargeOS is another PR.
Ref: https://github.com/wckr/wocker/pull/85